### PR TITLE
Fix YAML parsing crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "matchhostfsowner"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "chrono",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchhostfsowner"
-version = "0.9.7"
+version = "0.9.8"
 authors = ["Hongli Lai <honglilai@gmail.com>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ incremental = false
 panic = "abort"
 
 [dependencies]
-yaml-rust = "^0.4"
+yaml-rust = "^0.4.5"
 chrono = "^0.4.0"
 colored = "^1.6"
 log = { version = "^0.4.6", features = ["std"] }


### PR DESCRIPTION
There is [a bug](https://github.com/chyh1990/yaml-rust/issues/167) which causes parsing a perfectly valid YAML file to panick with the following error:

~~~
attempted to leave type `linked_hash_map::Node<yaml::Yaml, yaml::Yaml>` uninitialized, which is invalid, /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/linked-hash-map-0.5.2/src/lib.rs:174:52
~~~

This is apparently a compatibility problem with newer Rust compilers. Upgrading to yaml-rust 0.4.5 and linked-hash-map 0.5.4 fixes this problem.