### PR TITLE
Have GHA build releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build (release) for ${{ matrix.target }}
+        run: cargo build --release --target "${{ matrix.target }}" --verbose
+
+      - name: Resolve package name
+        id: pkg
+        run: |
+          PKG_NAME=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].name')
+          echo "pkg_name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Package artifact
+        run: |
+          set -euo pipefail
+          PKG=${{ steps.pkg.outputs.pkg_name }}
+          TGT=${{ matrix.target }}
+          TAG=${{ github.ref_name }}
+          BIN_PATH="target/${TGT}/release/${PKG}"
+          if [ ! -x "$BIN_PATH" ]; then
+            echo "Expected binary not found at $BIN_PATH"
+            ls -la "target/${TGT}/release" || true
+            exit 1
+          fi
+          ARCHIVE="${PKG}-${TAG}-${TGT}.tar.gz"
+          mkdir -p dist
+          tar -czf "dist/${ARCHIVE}" \
+            -C "target/${TGT}/release" "${PKG}"
+          echo "Created dist/${ARCHIVE}"
+          shasum -a 256 "dist/${ARCHIVE}" > "dist/${ARCHIVE}.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+          if-no-files-found: error
+
+  create_release:
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist-all
+
+      - name: Check gh CLI and auth
+        run: |
+          gh --version
+          gh auth status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update draft release with gh
+        run: |
+          set -euo pipefail
+          gh release create "${{ github.ref_name }}" --draft --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload assets to release
+        run: |
+          set -euo pipefail
+          find dist-all -type f -name '*.tar.gz' -o -name '*.sha256' | sort > files.txt
+          xargs -a files.txt -r gh release upload "${{ github.ref_name }}" --clobber
+          echo "Uploaded:"
+          cat files.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,14 +7,17 @@ on:
       - '*.png'
       - '*.jpg'
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v5
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -22,11 +25,11 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('Cargo.lock') }}
     - name: Build
-      run: cargo build --color=always --verbose
-    - uses: docker/setup-buildx-action@v2
-    - uses: docker/build-push-action@v4
+      run: cargo build --verbose
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/build-push-action@v6
       with:
         context: .
         file: Dockerfile.integration-test-base
@@ -35,4 +38,4 @@ jobs:
         cache-to: type=gha,mode=max
         load: true
     - name: Run tests
-      run: cargo test --color=always --verbose
+      run: cargo test --verbose


### PR DESCRIPTION
Add a GHA releaser which creates AMD64 and ARM64 releases.

Minor changes: creates tar.gz files for the releases

To create a draft release push a `v*.*` tag.